### PR TITLE
fix(seeder): to have deterministric generation we need to generate

### DIFF
--- a/cmd/rnd/main.go
+++ b/cmd/rnd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -18,7 +19,7 @@ func main() {
 	flag.Parse()
 	internal.Configure(dst)
 	log.Configure(slog.LevelDebug)
-	h := hero.New()
+	h := hero.New(context.Background())
 	fmt.Println(hero.String(h))
 	slog.Info("seeded with", "seed", dst)
 	slog.Debug("hero details", "hero", h)

--- a/handler/hero_test.go
+++ b/handler/hero_test.go
@@ -27,7 +27,7 @@ func TestGetHeroHandler(t *testing.T) {
 
 	resp := new(handler.HeroResponse)
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), resp))
-	assert.Equal(t, seed, resp.ID)
+	assert.Equal(t, want, resp.ID)
 	assert.Equal(t, "Turtlefolk", resp.Hero.Ancestry.Name)
 	assert.Equal(t, "Mage", resp.Hero.Class.Name)
 	assert.Equal(t, "Wild One", resp.Hero.Background.Name)

--- a/internal/hero/ancestry/ancestry.go
+++ b/internal/hero/ancestry/ancestry.go
@@ -1,6 +1,7 @@
 package ancestry
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -34,8 +35,8 @@ func init() {
 }
 
 // Select choose randomly an ancestry.
-func Select() Ancestry {
-	return internal.Choose(ancestries)
+func Select(ctx context.Context) Ancestry {
+	return internal.Choose(ctx, ancestries)
 }
 
 // All returns all available ancestries.

--- a/internal/hero/ancestry/ancestry_test.go
+++ b/internal/hero/ancestry/ancestry_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSelect(t *testing.T) {
 	assert.NotPanics(t, func() {
-		bg := ancestry.Select()
+		bg := ancestry.Select(t.Context())
 		t.Log(bg)
 	})
 }

--- a/internal/hero/background/background.go
+++ b/internal/hero/background/background.go
@@ -1,6 +1,7 @@
 package background
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -27,8 +28,8 @@ func init() {
 }
 
 // Select generate a random Background.
-func Select() Background {
-	return internal.Choose(bgs)
+func Select(ctx context.Context) Background {
+	return internal.Choose(ctx, bgs)
 }
 
 // All returns all available backgrounds.

--- a/internal/hero/background/background_test.go
+++ b/internal/hero/background/background_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSelect(t *testing.T) {
 	assert.NotPanics(t, func() {
-		bg := background.Select()
+		bg := background.Select(t.Context())
 		t.Log(bg)
 	})
 }

--- a/internal/hero/class/class.go
+++ b/internal/hero/class/class.go
@@ -1,6 +1,7 @@
 package class
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -32,8 +33,8 @@ func init() {
 	}
 }
 
-func Select() Class {
-	return internal.Choose(classes)
+func Select(ctx context.Context) Class {
+	return internal.Choose(ctx, classes)
 }
 
 func All() []Class {

--- a/internal/hero/class/class_test.go
+++ b/internal/hero/class/class_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSelect(t *testing.T) {
 	assert.NotPanics(t, func() {
-		c := class.Select()
+		c := class.Select(t.Context())
 		t.Log(c)
 	})
 }

--- a/internal/hero/hero.go
+++ b/internal/hero/hero.go
@@ -1,6 +1,7 @@
 package hero
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/meshenka/nimble/internal/hero/ancestry"
@@ -20,14 +21,14 @@ type Hero struct {
 	Quirks     []string              `json:"quirks"`
 }
 
-func New() Hero {
+func New(ctx context.Context) Hero {
 	return Hero{
-		Ancestry:   ancestry.Select(),
-		Class:      class.Select(),
-		Motivation: motivation.Select(),
-		Background: background.Select(),
-		Origin:     origin.Select(),
-		Quirks:     quirk.Select(),
+		Ancestry:   ancestry.Select(ctx),
+		Class:      class.Select(ctx),
+		Motivation: motivation.Select(ctx),
+		Background: background.Select(ctx),
+		Origin:     origin.Select(ctx),
+		Quirks:     quirk.Select(ctx),
 	}
 }
 

--- a/internal/hero/hero_test.go
+++ b/internal/hero/hero_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	h := hero.New()
+	h := hero.New(t.Context())
 	require.NotZero(t, h)
 
 	t.Run("string", func(t *testing.T) {

--- a/internal/hero/motivation/motivation.go
+++ b/internal/hero/motivation/motivation.go
@@ -1,6 +1,10 @@
 package motivation
 
-import "github.com/meshenka/nimble/internal"
+import (
+	"context"
+
+	"github.com/meshenka/nimble/internal"
+)
 
 var motivations = []string{
 	"I owe a life debt to someone in my party",
@@ -22,8 +26,8 @@ var motivations = []string{
 	"I'm following a prophecy",
 }
 
-func Select() string {
-	return internal.Choose(motivations)
+func Select(ctx context.Context) string {
+	return internal.Choose(ctx, motivations)
 }
 
 func All() []string {

--- a/internal/hero/motivation/motivation_test.go
+++ b/internal/hero/motivation/motivation_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSelect(t *testing.T) {
 	assert.NotPanics(t, func() {
-		bg := motivation.Select()
+		bg := motivation.Select(t.Context())
 		t.Log(bg)
 	})
 }

--- a/internal/hero/origin/origin.go
+++ b/internal/hero/origin/origin.go
@@ -1,6 +1,10 @@
 package origin
 
-import "github.com/meshenka/nimble/internal"
+import (
+	"context"
+
+	"github.com/meshenka/nimble/internal"
+)
 
 var origins = []string{
 	"The Shadow Blight",
@@ -41,8 +45,8 @@ var origins = []string{
 	"a Sunken Hold",
 }
 
-func Select() string {
-	return internal.Choose(origins)
+func Select(ctx context.Context) string {
+	return internal.Choose(ctx, origins)
 }
 
 func All() []string {

--- a/internal/hero/origin/origin_test.go
+++ b/internal/hero/origin/origin_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSelect(t *testing.T) {
 	assert.NotPanics(t, func() {
-		bg := origin.Select()
+		bg := origin.Select(t.Context())
 		t.Log(bg)
 	})
 }

--- a/internal/hero/quirk/quirk.go
+++ b/internal/hero/quirk/quirk.go
@@ -1,6 +1,10 @@
 package quirk
 
-import "github.com/meshenka/nimble/internal"
+import (
+	"context"
+
+	"github.com/meshenka/nimble/internal"
+)
 
 var quirks = []string{
 	"Adaptable",
@@ -97,10 +101,10 @@ var quirks = []string{
 	"Witty",
 }
 
-func Select() []string {
+func Select(ctx context.Context) []string {
 	descriptors := make([]string, 0, 3)
 	for range 3 {
-		descriptors = append(descriptors, internal.Choose(quirks))
+		descriptors = append(descriptors, internal.Choose(ctx, quirks))
 	}
 	return descriptors
 }

--- a/internal/hero/quirk/quirk_test.go
+++ b/internal/hero/quirk/quirk_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSelect(t *testing.T) {
-	have := quirk.Select()
+	have := quirk.Select(t.Context())
 	require.Len(t, have, 3)
 	assert.NotZero(t, have[0])
 }

--- a/internal/seed.go
+++ b/internal/seed.go
@@ -1,26 +1,62 @@
 package internal
 
 import (
+	"context"
 	"math/rand/v2"
 	"time"
 )
 
 var (
-	Seed uint64
-	rn   *rand.Rand
+	Seed          uint64
+	rn            *rand.Rand
+	defaultSeeder Rand
 )
 
 func init() {
 	Seed = uint64(time.Now().UnixNano())   //nolint:gosec // G115 int64->uint64 overflow
 	rn = rand.New(rand.NewPCG(Seed, 3999)) //nolint:gosec
+	defaultSeeder = Rand{
+		Seed: Seed,
+		rnd:  rn,
+	}
 }
 
-func Configure(s uint64) {
+func Configure(s uint64) Rand {
 	Seed = s
 	rn = rand.New(rand.NewPCG(Seed, 2999)) //nolint:gosec
+	return Rand{
+		Seed: s,
+		rnd:  rn,
+	}
 }
 
-func Choose[T any](options []T) T {
-	idx := rn.IntN(len(options))
+func Choose[T any](ctx context.Context, options []T) T {
+	seeder := Ctx(ctx)
+	idx := seeder.IntN(len(options))
 	return options[idx]
+}
+
+type Rand struct {
+	rnd  *rand.Rand
+	Seed uint64
+}
+
+func (r Rand) IntN(n int) int {
+	return r.rnd.IntN(n)
+}
+
+type key int
+
+const rndKey key = iota
+
+func WithContext(parent context.Context, seeder Rand) context.Context {
+	return context.WithValue(parent, rndKey, seeder)
+}
+
+func Ctx(ctx context.Context) Rand {
+	seeder := ctx.Value(rndKey)
+	if seeder != nil {
+		return seeder.(Rand)
+	}
+	return defaultSeeder
 }


### PR DESCRIPTION
a brand new seeder on each calls, otherwise each users will the same
seed.

It can also create a race condition if multiple users get a specific
hero, as the seed is a package variable.

With this change, we put a new seeder in request context, avoiding race
and reusing the same seed over and over.
